### PR TITLE
Agrego módulo de leader usando algoritmo Bully.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -238,3 +238,36 @@ services:
     depends_on:
       rabbitmq:
         condition: service_healthy
+
+  watchdog_1:
+    build:
+      context: .
+      dockerfile: leader/Dockerfile
+    command: python3 -u ./leader.py
+    environment:
+      PID: 1
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+
+  watchdog_2:
+    build:
+      context: .
+      dockerfile: leader/Dockerfile
+    command: python3 -u ./leader.py
+    environment:
+      PID: 2
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+
+  watchdog_3:
+    build:
+      context: .
+      dockerfile: leader/Dockerfile
+    command: python3 -u ./leader.py
+    environment:
+      PID: 3
+    depends_on:
+      rabbitmq:
+        condition: service_healthy

--- a/leader/Dockerfile
+++ b/leader/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.7-alpine
+
+RUN pip install pika
+
+COPY ./leader/ /leader/
+COPY ./constants/constants.py /leader/
+COPY ./middleware/rabbitmq_queue.py /leader/
+
+WORKDIR /leader/

--- a/leader/leader.py
+++ b/leader/leader.py
@@ -1,0 +1,153 @@
+import os
+import logging
+import time
+from rabbitmq_queue import RabbitMQQueue
+
+HEARTBEAT_INTERVAL = 0.3
+TIMEOUT_HEARTBEAT = 3*HEARTBEAT_INTERVAL
+TIMEOUT_TRANSFER = 0.5
+TIMEOUT_PROCESS = 2
+TIMEOUT_ANSWER = 2*TIMEOUT_TRANSFER + TIMEOUT_PROCESS
+# In Coulouris(2011) the length of the  timeout while waiting
+# for a COORDINATOR message after the process received an
+# ANSWER is not specified. By means of a simple sequence
+# diagram it becomes clear that the timeout must be longer
+# than the ANSWER timeout, in case the other process
+# is waiting for an ANSWER. Therefore it seems straightforward
+# to set it so:
+TIMEOUT_COORD = 2*TIMEOUT_ANSWER
+
+ELECTION_EXCHANGE = "electx"
+LEADER_EXCHANGE = "leaderx"
+
+class ElectableProcess:
+    """This class factorizes the leader election protocol.
+    When this process is chosen as a leader this class
+    runs callback on a separate thread."""
+    def __init__(self, pid, pid_list, callback):
+        """Starts the election protocol. Receives this
+        process' pid number, a list of other pids
+        and a callback function used when this process is
+        elected."""
+        self.pid = pid
+        self.pid_list = pid_list
+        self.onleader_callback = callback
+        logging.basicConfig(format='%(asctime)s [PID {}] %(message)s'.format(self.pid))
+
+        self.setup_queues()
+
+        logging.info("Waiting 10s for starting everything..")
+        time.sleep(10)
+        self.start_election()
+
+    def setup_queues(self):
+        self.exchange = RabbitMQQueue(
+            exchange=ELECTION_EXCHANGE, consumer=False, exchange_type="direct")
+        self.process_queue = RabbitMQQueue(
+            exchange=ELECTION_EXCHANGE, consumer=True, exchange_type="direct",
+                routing_keys=[str(self.pid)])
+        self.leader_ex = RabbitMQQueue(
+            exchange=LEADER_EXCHANGE, consumer=False)
+        self.leader_queue = RabbitMQQueue(
+            exchange=LEADER_EXCHANGE, consumer=True)
+
+    def process_message(self, ch, method, properties, body):
+        data = body.decode().split(',')
+        logging.info("Received {}".format(body.decode()))
+        if data[0] == "election":
+            logging.info("Sending answer,{} to {}".format(self.pid, data[1]))
+            self.exchange.publish("answer,{}".format(self.pid), data[1])
+        elif data[0] == "answer":
+            self.received_answer = True # atomic
+        elif data[0] == "coordinator":
+            self.leader = int(data[1]) # atomic
+
+    def start_election(self):
+        self.received_answer = False
+        self.leader = None
+
+        logging.info("Starting election -- sending ELECTION")
+        for remote_pid in self.pid_list:
+            if remote_pid > self.pid:
+                logging.info("Sending election,{} to {}".format(self.pid, remote_pid))
+                self.exchange.publish("election,{}".format(self.pid), str(remote_pid))
+
+        # If we do not receive an answer within the timeout,
+        # we are now the coordinator.
+        # This processes requests in another thread,
+
+        logging.info("Consuming from queue")
+
+        self.process_queue.async_consume(self.process_message)
+
+        logging.info("Sleeping for {}s".format(TIMEOUT_ANSWER))
+        time.sleep(TIMEOUT_ANSWER)
+        logging.info("Woke up from timeout")
+
+        if self.received_answer:
+            logging.info("Answer received!")
+            time.sleep(TIMEOUT_COORD)
+            logging.info("Woke up from coord timeout")
+            # same as before => factorize in a function?
+            if self.leader is None:
+                logging.info("NO leader still! Rebooting election")
+                self.start_election()
+            logging.info("NEW leader! id is: {}".format(self.leader))
+        else:
+            logging.info("NO answer received! Therefore I am the leader. Sending coord.")
+            # No answer received in timeout, therefore this process is leader
+            for remote_pid in self.pid_list:
+                if remote_pid < self.pid:
+                    logging.info("->coordinator,{} to key {}".format(self.pid, str(remote_pid)))
+                    self.exchange.publish("coordinator,{}".format(self.pid), str(remote_pid))
+            logging.info("Setting leader pid")
+            self.leader = self.pid
+
+
+        if self.leader == self.pid:
+            logging.info("Starting leader logic in this process")
+            #async self.onleader_callback()
+            self.start_leader()
+        else:
+            logging.info("Following leader...")
+            self.follow_leader()
+
+    def start_leader(self):
+        # set up leader heartbeat
+        while True:
+            logging.info("Sent heartbeat")
+            self.leader_ex.publish("heartbeat")
+            time.sleep(HEARTBEAT_INTERVAL)
+
+    def process_heartbeat(self, ch, method, properties, body):
+        self.last_heartbeat = time.time()
+
+    def follow_leader(self):
+        # in another process update the counter with the time
+        # this one just wakes up every fraction of a second updating
+        # the count
+        self.last_heartbeat = time.time() - 0.01
+        self.leader_queue.async_consume(self.process_heartbeat)
+        diff = time.time() - self.last_heartbeat
+
+        while diff < TIMEOUT_HEARTBEAT:
+            logging.info("Sleeping for {}s".format(TIMEOUT_HEARTBEAT - diff + 0.1))
+            time.sleep(TIMEOUT_HEARTBEAT - diff + 0.1) # So we don't over-wait
+            diff = time.time() - self.last_heartbeat
+
+        logging.info("Timed out leader. About to start a new election")
+        self.start_election()
+
+if __name__ == '__main__':
+    logging.basicConfig(format='%(asctime)s %(message)s',
+                        datefmt='%m/%d/%Y %H:%M:%S',
+                        level=logging.INFO)
+    logging.info("Started!")
+    import socket
+    logging.info("Host is: {}".format(socket.gethostname()))
+    pid = int(os.getenv("PID", -1))
+    logging.info("Pid is: {}".format(pid))
+    pids = [i for i in range(1,4) if i != pid]
+    proc = ElectableProcess(pid, pids, print)
+
+print("Called!!")

--- a/middleware/rabbitmq_queue.py
+++ b/middleware/rabbitmq_queue.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
 
 import pika
-
+import threading
+import time
+import logging
 HOST = 'rabbitmq'
 
 class RabbitMQQueue:
     def __init__(self, exchange, exchange_type='fanout', consumer=False, exclusive=False, queue_name='', routing_keys=[None]):
+        self.thread_stop = True
+        self.thread = None
         connection = pika.BlockingConnection(pika.ConnectionParameters(host=HOST))
         self.channel = connection.channel()
 
@@ -19,6 +23,7 @@ class RabbitMQQueue:
         for routing_key in routing_keys:
             self.channel.queue_bind(exchange=exchange, queue=self.queue_name, routing_key=routing_key)
 
+
     def publish(self, body, routing_key=''):
         self.channel.basic_publish(exchange=self.exchange, routing_key=routing_key, body=body,
                                    properties=pika.BasicProperties(delivery_mode=2,))
@@ -27,6 +32,29 @@ class RabbitMQQueue:
         self.tag = self.channel.basic_consume(queue=self.queue_name, auto_ack=True,
                                               on_message_callback=callback)
         self.channel.start_consuming()
+
+    def async_consume(self, callback):
+        """Start a thread and consume messages there.
+        Invariant: no more than one thread is consuming in an object
+        instance."""
+        logging.info("Async consume")
+        if self.thread is not None:
+            return
+        self.thread_stop = False
+
+        def wrapped_callback(ch, method, properties, body):
+            #logging.info("Wrapped callback'd")
+            callback(ch, method, properties, body)
+            #if not self.thread_stop:
+            #   callback(ch, method, properties, body)
+            #else:
+            #    print("Should stop now!")
+            #    callback(ch, method, properties, body)
+            #    self.channel.basic_cancel(self.tag)
+            #    exit
+
+        self.thread = threading.Thread(target=self.consume, args=(wrapped_callback,))
+        self.thread.start()
 
     def cancel(self):
         self.channel.basic_cancel(self.tag)


### PR DESCRIPTION
El algoritmo bully requiere de timeouts para detectar si un
proceso no está vivo. Esta implementación utiliza colas de
Rabbit para la comunicación de procesos, y la librería `Pika`
no dispone de primitivas con timeouts para poder consumir.
`Multiprocessing` tiene funciones como `apply_timeout` que
toman una función y le agregan la funcionalidad de timeout,
pero sólo funciona con funciones que son bastante puras.
Como no es el caso (consume recibe un callback y ahí
se arma en esquema de eventos), no es fácil usar esa función.
La solución que encontré por ahora es consumir en un thread
distinto y que el thread principal duerma hasta cumplir el
timeout. Al despertar revisa si recibió la información
suficiente (COORD, ANSWER, etc). Lo malo de esto es que
siempre espera hasta el timeout en vez de procesarlo antes,
pero no parece traer complicaciones mayores.

La idea de la clase ElectableProcess es que sea el punto
de entrada de un proceso y que se especifice un callback
a ejecutar cuando sea votado líder. De esta manera se
factoriza la lógica de la elección de la de negocio.

Ejemplo de elección al iniciar los 3 procesos:
![2019-11-27-230741_1334x815_scrot](https://user-images.githubusercontent.com/290523/69771623-3b76c100-116c-11ea-93d6-b6368f092a72.png)

mato al proceso 3 y los restantes arman una elección:

![2019-11-27-230827_1321x643_scrot](https://user-images.githubusercontent.com/290523/69771634-47fb1980-116c-11ea-8443-b4455fa96785.png)

mato al proceso 2 y el restante se elige como líder:

![2019-11-27-230918_1336x282_scrot](https://user-images.githubusercontent.com/290523/69771644-51848180-116c-11ea-9692-450178ea34a6.png)



