### PR TITLE
Restablezco auto-ack en watchdog+leader

### DIFF
--- a/leader/leader.py
+++ b/leader/leader.py
@@ -83,7 +83,7 @@ class ElectableProcess:
 
         logging.info("Consuming from queue")
 
-        self.process_queue.async_consume(self.process_message)
+        self.process_queue.async_consume(self.process_message, auto_ack=True)
 
         logging.info("Sleeping for {}s".format(TIMEOUT_ANSWER))
         time.sleep(TIMEOUT_ANSWER)
@@ -136,7 +136,7 @@ class ElectableProcess:
         # this one just wakes up every fraction of a second updating
         # the count
         self.last_heartbeat = time.time() - 0.01
-        self.leader_queue.async_consume(self.process_heartbeat)
+        self.leader_queue.async_consume(self.process_heartbeat, auto_ack=True)
         diff = time.time() - self.last_heartbeat
 
         while diff < TIMEOUT_HEARTBEAT:

--- a/middleware/rabbitmq_queue.py
+++ b/middleware/rabbitmq_queue.py
@@ -28,12 +28,13 @@ class RabbitMQQueue:
         self.channel.basic_publish(exchange=self.exchange, routing_key=routing_key, body=body,
                                    properties=pika.BasicProperties(delivery_mode=2,))
 
-    def consume(self, callback):
+    def consume(self, callback, auto_ack=False):
         self.channel.basic_qos(prefetch_count=1)
-        self.tag = self.channel.basic_consume(queue=self.queue_name, on_message_callback=callback)
+        self.tag = self.channel.basic_consume(queue=self.queue_name, auto_ack=auto_ack,
+                    on_message_callback=callback)
         self.channel.start_consuming()
 
-    def async_consume(self, callback):
+    def async_consume(self, callback, auto_ack=False):
         """Start a thread and consume messages there.
         Invariant: no more than one thread is consuming in an object
         instance."""
@@ -53,7 +54,8 @@ class RabbitMQQueue:
             #    self.channel.basic_cancel(self.tag)
             #    exit
 
-        self.thread = threading.Thread(target=self.consume, args=(wrapped_callback,))
+        self.thread = threading.Thread(target=self.consume, args=(wrapped_callback,),
+                kwargs={"auto_ack":auto_ack})
         self.thread.start()
 
     def cancel(self):

--- a/watchdog/heartbeatprocess.py
+++ b/watchdog/heartbeatprocess.py
@@ -31,11 +31,14 @@ class HeartbeatProcess:
         self.hostname = hostname
         self.metadata = metadata
         self.callback = callback
-        logging.basicConfig(format='%(asctime)s [PID {}] %(message)s'.format(self.hostname))
-        logging.info("Instancing heartbeat process for hostname {}".format(hostname))
         self.exchange = RabbitMQQueue(
             exchange=HEARTBEAT_EXCHANGE,
             consumer=False, exchange_type="fanout")
+        logging.basicConfig(format='%(asctime)s [PID {}] %(message)s'.format(self.hostname),
+            level = logging.INFO)
+
+        logging.info("Instancing heartbeat process for hostname {}".format(hostname))
+
 
     @staticmethod
     def setup(classname, *args, **kwargs):
@@ -54,6 +57,9 @@ class HeartbeatProcess:
         self.thread.start()
     def periodic_heartbeat(self):
         while True:
+            logging.debug("Sending heartbeat -- message is {}".format(
+                "heartbeat,{},{}".format(self.hostname, self.metadata)
+            ))
             self.exchange.publish("heartbeat,{},{}".format(self.hostname, self.metadata))
             time.sleep(HEARTBEAT_INTERVAL)
 

--- a/watchdog/watchdog.py
+++ b/watchdog/watchdog.py
@@ -63,6 +63,7 @@ class WatchdogProcess:
         # TODO: special case for storage (master & replicas)
 
     def process_heartbeat(self, ch, method, properties, body):
+        logging.debug("Received heartbeat message is {}".format(str(body)))
         data = body.decode().split(',')
         recv_hostname = data[1]
         recv_metadata = data[2]
@@ -105,7 +106,7 @@ class WatchdogProcess:
         self.respawning[imgid] = False
 
     def launch_receiver_thread(self):
-        self.leader_queue.async_consume(self.process_heartbeat)
+        self.leader_queue.async_consume(self.process_heartbeat, auto_ack=True)
 
     def launch_checker(self):
         while True:


### PR DESCRIPTION
Restablezco auto-ack en watchdog+leader, que se había sacado. Modifiqué el middleware para aceptar la opción (por defecto es False). Realmente no importa acá si hay un ack y se cayó el nodo,
son heartbeats o mensajes de elección que se pueden ignorar. El protocolo es robusto a eso.